### PR TITLE
Add ignore option to interface.yaml

### DIFF
--- a/interface.yaml
+++ b/interface.yaml
@@ -1,3 +1,9 @@
 name: keystone
 summary: Interface for integrating with Keystone identity service
 maintainer: OpenStack Charmers <openstack-charmers@lists.ubuntu.com>
+ignore:
+  - 'units_tests'
+  - 'Makefile'
+  - '.testr.conf'
+  - 'test-requirements.txt'
+  - 'tox.ini'


### PR DESCRIPTION
This stops the test files from being copied into the built charm.
(Note this will only work when the relevant bug in charm-tools (192) lands.  Alternative workarounds will be needed in the built charm as this option has no effect in an interface.
The bug is: https://github.com/juju/charm-tools/issues/192 for tracking purposes.